### PR TITLE
tasks.py: redirect subprocess streams

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -53,9 +53,9 @@ def main(argv):
         print app.conf.humanize(with_defaults=False, censored=True)
         sys.stderr.write('USAGE: python %s OUT ERR CMD\n' % argv[0])
         sys.exit(2)
-    r = run.delay(args=argv[1:])
-    print r
+    return run.delay(args=argv[1:])
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    r = main(sys.argv)
+    print r


### PR DESCRIPTION
Changes `tasks.py` to redirect std{out,err} from the called subprocess to the specified files. On one hand this is safer in case they get very large (e.g., Bio-Formats log messages for a large .screen file); on the other hand, this allows to systematically keep all info from the subprocess after https://github.com/simleo/pydoop-features/pull/41.

The app creates any required directories in case they don't exist, so that the caller is allowed to place logs under directories that will (would) be created by the individual tasks. pydoop-features apps also create required directories if they don't exist, but since in all cases this is done in [EAFP style](https://docs.python.org/3/glossary.html#term-eafp) there should be no race conditions (hopefully).